### PR TITLE
Allow iteratee to be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(batchSize, arr, fn) {
   .reduce(function(chain, group) {
     return chain.then(function() {
       return Promise.all(group.map(function(x, i) {
-        return fn(x, i).then(function(result) {
+        return (!fn ? Promise.resolve(x) : fn(x, i))["then"](function(result) {
           results.push(result);
         });
       }));

--- a/test.js
+++ b/test.js
@@ -35,6 +35,13 @@ describe('batchPromises', function() {
     });
   });
 
+  it('should not require iteratee function', function() {
+    return batchPromises(2, [1,2,3,4,5])
+    .then(function(res) {
+      assert.deepEqual(res, [1,2,3,4,5]);
+    });
+  })
+
   it('should reject on an error and halt execution', function() {
     var highestPromise;
     var error = new Error('something went wrong');


### PR DESCRIPTION
Just a thought, but the iteratee could be optional?  If you don't require anything fancy between batches, you could simply `Promise.resolve` each batch.

Was going to submit an issue, but it was a 2 second job for a PR.  Let me know your thoughts.